### PR TITLE
Fix "Apache License, Version 2.0" spelling

### DIFF
--- a/jasypt-acegisecurity/pom.xml
+++ b/jasypt-acegisecurity/pom.xml
@@ -34,7 +34,7 @@
 
   <licenses>
     <license>
-      <name>The Apache Software License, Version 2.0</name>
+      <name>Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>

--- a/jasypt-dist/pom.xml
+++ b/jasypt-dist/pom.xml
@@ -34,7 +34,7 @@
 
   <licenses>
     <license>
-      <name>The Apache Software License, Version 2.0</name>
+      <name>Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>

--- a/jasypt-hibernate3/pom.xml
+++ b/jasypt-hibernate3/pom.xml
@@ -34,7 +34,7 @@
 
   <licenses>
     <license>
-      <name>The Apache Software License, Version 2.0</name>
+      <name>Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>

--- a/jasypt-hibernate4/pom.xml
+++ b/jasypt-hibernate4/pom.xml
@@ -34,7 +34,7 @@
 
   <licenses>
     <license>
-      <name>The Apache Software License, Version 2.0</name>
+      <name>Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>

--- a/jasypt-spring2/pom.xml
+++ b/jasypt-spring2/pom.xml
@@ -34,7 +34,7 @@
 
   <licenses>
     <license>
-      <name>The Apache Software License, Version 2.0</name>
+      <name>Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>

--- a/jasypt-spring3-testapp/pom.xml
+++ b/jasypt-spring3-testapp/pom.xml
@@ -33,7 +33,7 @@
 
   <licenses>
     <license>
-      <name>The Apache Software License, Version 2.0</name>
+      <name>Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>

--- a/jasypt-spring3/pom.xml
+++ b/jasypt-spring3/pom.xml
@@ -34,7 +34,7 @@
 
   <licenses>
     <license>
-      <name>The Apache Software License, Version 2.0</name>
+      <name>Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>

--- a/jasypt-spring31-testapp/pom.xml
+++ b/jasypt-spring31-testapp/pom.xml
@@ -33,7 +33,7 @@
 
   <licenses>
     <license>
-      <name>The Apache Software License, Version 2.0</name>
+      <name>Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>

--- a/jasypt-spring31/pom.xml
+++ b/jasypt-spring31/pom.xml
@@ -34,7 +34,7 @@
 
   <licenses>
     <license>
-      <name>The Apache Software License, Version 2.0</name>
+      <name>Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>

--- a/jasypt-springsecurity2/pom.xml
+++ b/jasypt-springsecurity2/pom.xml
@@ -34,7 +34,7 @@
 
   <licenses>
     <license>
-      <name>The Apache Software License, Version 2.0</name>
+      <name>Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>

--- a/jasypt-springsecurity3/pom.xml
+++ b/jasypt-springsecurity3/pom.xml
@@ -34,7 +34,7 @@
 
   <licenses>
     <license>
-      <name>The Apache Software License, Version 2.0</name>
+      <name>Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>

--- a/jasypt-wicket13/pom.xml
+++ b/jasypt-wicket13/pom.xml
@@ -34,7 +34,7 @@
 
   <licenses>
     <license>
-      <name>The Apache Software License, Version 2.0</name>
+      <name>Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>

--- a/jasypt-wicket15/pom.xml
+++ b/jasypt-wicket15/pom.xml
@@ -34,7 +34,7 @@
 
   <licenses>
     <license>
-      <name>The Apache Software License, Version 2.0</name>
+      <name>Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>

--- a/jasypt/pom.xml
+++ b/jasypt/pom.xml
@@ -34,7 +34,7 @@
 
   <licenses>
     <license>
-      <name>The Apache Software License, Version 2.0</name>
+      <name>Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>


### PR DESCRIPTION
There are many Java libraries licensed under "Apache License, Version 2.0" that do not use its official spelling.
This causes issues like https://issues.apache.org/jira/browse/MPIR-382: with every library defining its own spelling, it's difficult in large projects to have a clear view of all licenses in use.
This PR changes the license spelling to the official one, as advised by Maven developers.